### PR TITLE
[Feat] 공통 응답 클래스 추가

### DIFF
--- a/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
+++ b/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
@@ -1,0 +1,123 @@
+package discordstudy.calender.global.dto;
+
+import discordstudy.calender.global.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * 공통 응답을 위한 객체
+ * <p>
+ * ResponseEntity 내부에 제네릭으로 사용
+ * <pre>
+ * {@code
+ * public ResponseEntity<ApiResponse<Object>> apiMethod(){
+ *     //Do Somethings....
+ *     return ApiResponse.ok();
+ *  }
+ * }
+ */
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    /**
+     * Http 상태 코드를 표시
+     */
+    private final Integer status;
+
+    /**
+     * 메타 데이터를 위한 메시지
+     */
+    private final String message;
+    /**
+     * 응답에 대한 데이터
+     */
+    private final T data;
+
+    /**
+     * 응답에 따른 데이터가 없어도 되는 경우 사용
+     * <p>
+     * 메시지 : Success
+     */
+    public static ResponseEntity<ApiResponse<Void>> ok() {
+        return ResponseEntity.ok(
+                ApiResponse.<Void>builder()
+                        .status(HttpStatus.OK.value())
+                        .data(null)
+                        .message("Success")
+                        .build()
+        );
+    }
+
+    /**
+     * 클라이언트에게 데이터를 전달 할 때 사용<p>
+     *
+     * @param data 클라이언트에 전달 할 데이터<br>
+     *             메시지 : Success
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> ok(T data) {
+        return ResponseEntity.ok(
+                ApiResponse.<T>builder()
+                        .status(HttpStatus.OK.value())
+                        .data(data)
+                        .message("Success")
+                        .build()
+        );
+    }
+
+    /**
+     * 클라이언트에게 메시지와 데이터를 전달 할 때 사용<p>
+     *
+     * @param message 직접 입력한 메시지<p>
+     * @param data    클라이언트에 전달 할 데이터<p>
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> okWithMessage(String message, T data) {
+        return ResponseEntity.ok(
+                ApiResponse.<T>builder()
+                        .status(HttpStatus.OK.value())
+                        .data(data)
+                        .message(message)
+                        .build()
+        );
+    }
+
+    /**
+     * 예외 발생시 클라이언트에게 알릴 때 사용<p>
+     *
+     * @param errorCode 에러코드 목록은 {@link ErrorCode}을 참조<p>
+     *                  원하는 에러코드가 없을 때, ErrorCode 새로 추가
+     *                  또는{@link ApiResponse#errorCustom(HttpStatus, String) errorCustom} 중 선택하여 사용
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(
+                        ApiResponse.<T>builder()
+                                .status(errorCode.getHttpStatus().value())
+                                .data(null)
+                                .message(errorCode.getMessage())
+                                .build()
+                );
+    }
+
+    /**
+     * 예외 발생시 클라이언트에게 알릴 에러코드 사용<p>
+     *
+     * @param status  클라이언트에게 전달 할 {@link HttpStatus}<br>
+     * @param message 클라이언트에게 전달 할 메시지<br>
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> errorCustom(HttpStatus status, String message) {
+        return ResponseEntity.status(status.value())
+                .body(
+                        ApiResponse.<T>builder()
+                                .status(status.value())
+                                .data(null)
+                                .message(message)
+                                .build()
+                );
+    }
+}

--- a/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
+++ b/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
@@ -1,0 +1,36 @@
+package discordstudy.calender.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 프로젝트에서 발생하는 예외에 대해 사전에 정의해놓은 Enum<br>
+ * 필요한 에러코드가 없는 경우 직접 만들어서 사용<br>
+ * 만들때 이름은 상수 & 언더스코어만 사용할것<br>
+ *
+ * @see <a href="https://naver.github.io/hackday-conventions-java/#constant_uppercase">코딩 컨벤션</a>
+ */
+@Getter
+public enum ErrorCode {
+
+    //COMMON
+    NOT_FOUND(HttpStatus.NOT_FOUND, "경로가 올바르지 않습니다"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+
+    // USER
+    USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 비밀번호가 일치하지 않습니다."),
+
+    // 5xx
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        httpStatus = status;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
# ⭐️ Pull Request 요약
- 클라이언트에게 전달할 데이터에 대한 일관성 유지와 예외 처리에 용이성을 위한 코드 추가
- ResponseEntity 내에 굳이 ApiResponse 를 사용하는 이유
  - 일관된 응답 구조 유지 : 메시지나 상태코드 등을 통해 클라이언트 측에서 예외 처리가 용이 해질 수 있음 
  - 예외 처리에 용이 : 기존의 상태코드 말고도 메시지나 그 외 다른 메타데이터를 포함한 응답을 보내 줄 수 있음

## 🛠️ 변경 사항

- 예외 처리 용도의 ErrorCode
- 공통 응답을 위한 클래스 ApiResponse

## 💡 관련 이슈

- #10 

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-01)
- 작업 종료일: (2024-09-01)

## 📌 유의사항

- 앞으로 컨트롤러 응답을 아래처럼 사용하면 됨
```java
    public ResponseEntity<ApiResponse<Void>> apiMethod() {
        //Do Something
        return ApiResponse.ok();
    }
```

## 🔗 참고문헌

- [정적 팩토리 메소드(메소드에 static 붙인 이유)](https://velog.io/@cjh8746/%EC%A0%95%EC%A0%81-%ED%8C%A9%ED%86%A0%EB%A6%AC-%EB%A9%94%EC%84%9C%EB%93%9CStatic-Factory-Method)
- [제네릭](https://inpa.tistory.com/entry/JAVA-%E2%98%95-%EC%A0%9C%EB%84%A4%EB%A6%ADGenerics-%EA%B0%9C%EB%85%90-%EB%AC%B8%EB%B2%95-%EC%A0%95%EB%B3%B5%ED%95%98%EA%B8%B0)
- [JavaDoc](https://velog.io/@ming/JavaDoc-%EC%A3%BC%EC%84%9D-%EC%95%8C%EA%B3%A0%EC%93%B0%EC%9E%90)