### PR TITLE
[Feat] 커스텀 헤더용 메소드 추가

### DIFF
--- a/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
+++ b/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
@@ -76,11 +76,31 @@ public class ApiResponse<T> {
     /**
      * 클라이언트에게 커스텀 헤더를 추가하여 데이터를 전달 할 때 사용<p>
      *
+     * @param data  클라이언트에 전달 할 데이터<br>
+     *              메시지 : Success
+     * @param key   헤더의 키
+     * @param value 헤더의 밸류
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> okWithCustomHeader(T data, String key, String value) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(key, value)
+                .body(
+                        ApiResponse.<T>builder()
+                                .status(HttpStatus.OK.value())
+                                .data(data)
+                                .message("Success")
+                                .build()
+                );
+    }
+
+    /**
+     * 클라이언트에게 커스텀 헤더쌍들을 추가하여 데이터를 전달 할 때 사용<p>
+     *
      * @param data   클라이언트에 전달 할 데이터<br>
      *               메시지 : Success
      * @param header Key에 헤더의 key, Value 에 헤더의 value
      */
-    public static <T> ResponseEntity<ApiResponse<T>> okWithCustomHeader(T data, Map<String, String> header) {
+    public static <T> ResponseEntity<ApiResponse<T>> okWithCustomHeaders(T data, Map<String, String> header) {
         HttpHeaders headers = new HttpHeaders();
 
         for (Map.Entry<String, String> map : header.entrySet()) {

--- a/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
+++ b/src/main/java/discordstudy/calender/global/dto/ApiResponse.java
@@ -5,8 +5,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
 
 /**
  * 공통 응답을 위한 객체
@@ -68,6 +71,31 @@ public class ApiResponse<T> {
                         .message("Success")
                         .build()
         );
+    }
+
+    /**
+     * 클라이언트에게 커스텀 헤더를 추가하여 데이터를 전달 할 때 사용<p>
+     *
+     * @param data   클라이언트에 전달 할 데이터<br>
+     *               메시지 : Success
+     * @param header Key에 헤더의 key, Value 에 헤더의 value
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> okWithCustomHeader(T data, Map<String, String> header) {
+        HttpHeaders headers = new HttpHeaders();
+
+        for (Map.Entry<String, String> map : header.entrySet()) {
+            headers.add(map.getKey(), map.getValue());
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .headers(headers)
+                .body(
+                        ApiResponse.<T>builder()
+                                .status(HttpStatus.OK.value())
+                                .data(data)
+                                .message("Success")
+                                .build()
+                );
     }
 
     /**


### PR DESCRIPTION
# ⭐️ Pull Request 요약
- 커스텀 헤더를 추가하기 위한 ApiResponse 메소드 추가

## 🛠️ 변경 사항

- ApiResponse 에 헤더를 추가하기 위한 메소드 2개 추가
  - okWithCustomHeader : String key, value를 추가하여 사용
  - okWithCustomHeaders : 헤더 여러개를 추가 할 때 map 을 활용하여 사용

## 💡 관련 이슈

- #13

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-02)
- 작업 종료일: (2024-09-02)
