### PR TITLE
[Feat] 전통적인 방식의 로그인 구현 + 시큐리티 구현 ! 

### DIFF
--- a/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
+++ b/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
@@ -35,8 +35,6 @@ public class MemberController {
         {
             return ResponseEntity.ok().build();//로그인 성공시 ok를 보내고 싶음
         }
-        else{
-            return ResponseEntity.status(401).build();//인증 실패시에는 401 권한 오류 설정
-        }
+        return ResponseEntity.status(401).build();
     }
 }

--- a/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
+++ b/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package discordstudy.calender.domain.member.controller;
 
+import discordstudy.calender.domain.member.dto.LoginRequest;
 import discordstudy.calender.domain.member.dto.SignupRequest;
 import discordstudy.calender.domain.member.dto.SignupResponse;
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.service.MemberService;
+import discordstudy.calender.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,5 +26,17 @@ public class MemberController {
         Member savedMember=memberService.registermember(request);
         SignupResponse response=new SignupResponse(savedMember);
         return ResponseEntity.ok().build();
+    }
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@RequestBody LoginRequest request)
+    {
+        boolean authenticate = memberService.authenticate(request);
+        if(authenticate)//회원가입이 성공한 회원 ! 이라면
+        {
+            return ResponseEntity.ok().build();//로그인 성공시 ok를 보내고 싶음
+        }
+        else{
+            return ResponseEntity.status(401).build();//인증 실패시에는 401 권한 오류 설정
+        }
     }
 }

--- a/src/main/java/discordstudy/calender/domain/member/dto/LoginRequest.java
+++ b/src/main/java/discordstudy/calender/domain/member/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package discordstudy.calender.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/discordstudy/calender/domain/member/dto/LoginRequest.java
+++ b/src/main/java/discordstudy/calender/domain/member/dto/LoginRequest.java
@@ -1,8 +1,10 @@
 package discordstudy.calender.domain.member.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class LoginRequest {
     private String loginId;
     private String password;

--- a/src/main/java/discordstudy/calender/domain/member/entity/Member.java
+++ b/src/main/java/discordstudy/calender/domain/member/entity/Member.java
@@ -18,7 +18,7 @@ public class Member {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "loginId",nullable = false)
+    @Column(name = "loginId",nullable = false,unique = true)
     private String loginId;
 
     @Column(name = "nickname",nullable = false)

--- a/src/main/java/discordstudy/calender/domain/member/repository/MemberRepository.java
+++ b/src/main/java/discordstudy/calender/domain/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package discordstudy.calender.domain.member.repository;
 import discordstudy.calender.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member,Long> {
+import java.util.Optional;
 
+public interface MemberRepository extends JpaRepository<Member,Long> {
+    Optional<Member> findByLoginId(String loginId);
 }

--- a/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
@@ -1,9 +1,11 @@
 package discordstudy.calender.domain.member.service;
 
+import discordstudy.calender.domain.member.dto.LoginRequest;
 import discordstudy.calender.domain.member.dto.SignupRequest;
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     //회원가입은 Save를 해야함 !
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public Member registermember(SignupRequest request)
 
@@ -19,6 +22,17 @@ public class MemberService {
         Member member=new Member(request.getLoginId(), request.getNickname(), request.getNickname());
         return memberRepository.save(member);
     }
+
+    public boolean authenticate(LoginRequest request)
+    {
+        Member member = memberRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 로그인 아이디 나 패스워드 입니다"));
+
+        return passwordEncoder.matches(request.getPassword(), member.getPassword());
+        //entity 객체인 member의 password와 요청dto로 들어온 request의 password를 비교해서
+        //맞으면 true 아니면 false를 가짐
+    }
+
 
 
 }

--- a/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
@@ -18,8 +18,8 @@ public class MemberService {
     public Member registermember(SignupRequest request)
 
     {
-//
-        Member member=new Member(request.getLoginId(), request.getNickname(), request.getNickname());
+        String encodedPassword=passwordEncoder.encode(request.getPassword());
+        Member member=new Member(request.getLoginId(), request.getNickname(), encodedPassword);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
+++ b/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,12 +18,18 @@ public class SecurityConfig {
         http
                 .csrf(csrf->csrf.disable())
                 .authorizeHttpRequests((requests)->requests
-                        .requestMatchers("/","/members/signup").permitAll()//
+                        .requestMatchers("/","/members/signup","/members/login").permitAll()//
                         .anyRequest().authenticated()//그외의 모든 요청은 인증요구
                 )
                 .logout((logout) -> logout.permitAll()); // 로그아웃 접근도 모두 허용
 
                 return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder()
+    {
+        return new BCryptPasswordEncoder();//Bcrypt 패스워드 인코딩 방식 사용 !
     }
 
 

--- a/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
+++ b/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -18,10 +19,10 @@ public class SecurityConfig {
         http
                 .csrf(csrf->csrf.disable())
                 .authorizeHttpRequests((requests)->requests
-                        .requestMatchers("/","/members/signup","/members/login").permitAll()//
+                        .requestMatchers("/","/members/*").permitAll()//
                         .anyRequest().authenticated()//그외의 모든 요청은 인증요구
                 )
-                .logout((logout) -> logout.permitAll()); // 로그아웃 접근도 모두 허용
+                .logout(LogoutConfigurer::permitAll); // 로그아웃 접근도 모두 허용
 
                 return http.build();
     }


### PR DESCRIPTION
# ⭐️ Pull Request 요약

전통적인 방식의 로그인 구현 과 시큐리티 구현을 했습니다 ! 

## 🛠️ 변경 사항

LoginRequest : 사용자가 로그인 요청을 할 때 쓰는 dto 입니다 loginid와 password를 보내는 역할을 합니다

MemberController : 요청 body로 loginRequest를 받아서 Service 로직의 authenticate 메서드를 불러와서 이 사용자가 실제 db에 저장되어 있는 ( 회원가입이 되어있는지 ) 확인 하고 성공하면 ok 실패하면 401 오류를 뱉습니다

MemberService :  authenticate 메서드는 memberRepository에 실제 사용자의 로그인 id가 있는지 체크 함 ! 

MemberRepository : findByLoginId(String loginId) 를 추가함  loginid를 기준으로 탐색하기 위해서 추가 

SecurityConfig : 로그인 부분인 "/members/login " 경로 추가 

password 인코딩을 위해서 password bean을 추가함 

## 💡 관련 이슈

- #9 번 작업입니다

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-02)
- 작업 종료일: (2024-09-02)

## 📌 유의사항



## 🔗 참고문헌


## 💡 새롭게 알게 된 사실

JpaRepository 는 CrudRepository를 상속받음 = > 그래서 save findby같은 메서드를 사용할 수 있었음

쿼리 메서드의 명명 규칙

ex ) findByName()  = > name컬럼의 값중 파라미터로 들어오는 값과 같은 데이터 반환 

만약 findbyLogin(String loginId) 라면 = > 파라미터인 String loginid와 같은값 반환

sql 쿼리는 WHERE loginid=#{loginid} 로 요청함 ! 

