### PR TITLE
[Feat] Jwt Token 생성 + 토큰을 이용한 로그인 / 회원가입 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON parsing을 위한 Jackson 사용
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
+++ b/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.service.MemberService;
 import discordstudy.calender.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,20 +22,20 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(@RequestBody SignupRequest request)
-    {
-        Member savedMember=memberService.registermember(request);
-        SignupResponse response=new SignupResponse(savedMember);
+    public ResponseEntity<Void> signup(@RequestBody SignupRequest request) {
+        Member savedMember = memberService.registermember(request);
+        SignupResponse response = new SignupResponse(savedMember);
         return ResponseEntity.ok().build();
     }
+
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(@RequestBody LoginRequest request)
-    {
-        boolean authenticate = memberService.authenticate(request);
-        if(authenticate)//회원가입이 성공한 회원 ! 이라면
+    public ResponseEntity<ApiResponse<String>> login(@RequestBody LoginRequest request) {
+        String token = memberService.authenticate(request);//jwt토큰 생성
+        if (token != null)//회원가입이 성공한 회원 ! 이라면
         {
-            return ResponseEntity.ok().build();//로그인 성공시 ok를 보내고 싶음
+            //return ApiResponse.okWithMessage("로그인 성공",token);
+            return ApiResponse.okWithCustomHeader("로그인 성공", "Authorization", "Bearer" + token);
         }
-        return ResponseEntity.status(401).build();
+        return ApiResponse.errorCustom(HttpStatus.UNAUTHORIZED, "로그인 실패");
     }
 }

--- a/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
+++ b/src/main/java/discordstudy/calender/domain/member/controller/MemberController.java
@@ -31,11 +31,7 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<String>> login(@RequestBody LoginRequest request) {
         String token = memberService.authenticate(request);//jwt토큰 생성
-        if (token != null)//회원가입이 성공한 회원 ! 이라면
-        {
-            //return ApiResponse.okWithMessage("로그인 성공",token);
-            return ApiResponse.okWithCustomHeader("로그인 성공", "Authorization", "Bearer" + token);
-        }
-        return ApiResponse.errorCustom(HttpStatus.UNAUTHORIZED, "로그인 실패");
+
+        return ApiResponse.okWithCustomHeader("로그인 성공", "Authorization", "Bearer" + token);
     }
 }

--- a/src/main/java/discordstudy/calender/domain/member/entity/Member.java
+++ b/src/main/java/discordstudy/calender/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package discordstudy.calender.domain.member.entity;
 
+import discordstudy.calender.domain.team.enums.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,9 +28,13 @@ public class Member {
     @Column(name = "password",nullable = true)
     private String password;
 
-    public Member(String loginId, String nickname, String password) {
+    @Enumerated(EnumType.STRING)//Role 문자열로 저장
+    @Column(name="role",nullable = false)
+    private Role role;
+    public Member(String loginId, String nickname, String password,Role role) {
         this.loginId = loginId;
         this.nickname = nickname;
         this.password = password;
+        this.role=role;
     }
 }

--- a/src/main/java/discordstudy/calender/domain/member/repository/MemberRepository.java
+++ b/src/main/java/discordstudy/calender/domain/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/discordstudy/calender/domain/member/service/CustomMemberDetailsService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/CustomMemberDetailsService.java
@@ -1,0 +1,30 @@
+package discordstudy.calender.domain.member.service;
+
+import discordstudy.calender.domain.member.entity.Member;
+import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.global.exception.ApplicationException;
+import discordstudy.calender.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomMemberDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByLoginId(username)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND));
+
+        return User.builder()
+                .username(member.getLoginId())
+                .password(member.getPassword())
+                .roles("USER")
+                .build();
+    }
+}

--- a/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
@@ -4,11 +4,15 @@ import discordstudy.calender.domain.member.dto.LoginRequest;
 import discordstudy.calender.domain.member.dto.SignupRequest;
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.domain.team.enums.Role;
+import discordstudy.calender.global.config.jwt.JwtTokenProvider;
 import discordstudy.calender.global.exception.ApplicationException;
 import discordstudy.calender.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,22 +20,27 @@ public class MemberService {
     //회원가입은 Save를 해야함 !
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public Member registermember(SignupRequest request) {
-        String encodedPassword=passwordEncoder.encode(request.getPassword());
-        Member member=new Member(request.getLoginId(), request.getNickname(), encodedPassword);
+        if (memberRepository.existsByLoginId(request.getLoginId())) {
+            throw new ApplicationException(ErrorCode.DUPLICATED_LOGINID);
+        }
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        Member member = new Member(request.getLoginId(), request.getNickname(), encodedPassword, Role.MEMBER);
         return memberRepository.save(member);
     }
 
-    public boolean authenticate(LoginRequest request) {
+    public String authenticate(LoginRequest request) {
         Member member = memberRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND));
 
-        return passwordEncoder.matches(request.getPassword(), member.getPassword());
-        //entity 객체인 member의 password와 요청dto로 들어온 request의 password를 비교해서
-        //맞으면 true 아니면 false를 가짐
-    }
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
+        }
 
+        return jwtTokenProvider.createToken(member.getLoginId(), List.of(member.getRole().toString()));
+    }
 
 
 }

--- a/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
@@ -17,16 +17,13 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Member registermember(SignupRequest request)
-
-    {
+    public Member registermember(SignupRequest request) {
         String encodedPassword=passwordEncoder.encode(request.getPassword());
         Member member=new Member(request.getLoginId(), request.getNickname(), encodedPassword);
         return memberRepository.save(member);
     }
 
-    public boolean authenticate(LoginRequest request)
-    {
+    public boolean authenticate(LoginRequest request) {
         Member member = memberRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND));
 

--- a/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
+++ b/src/main/java/discordstudy/calender/domain/member/service/MemberService.java
@@ -4,6 +4,8 @@ import discordstudy.calender.domain.member.dto.LoginRequest;
 import discordstudy.calender.domain.member.dto.SignupRequest;
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.global.exception.ApplicationException;
+import discordstudy.calender.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,7 +28,7 @@ public class MemberService {
     public boolean authenticate(LoginRequest request)
     {
         Member member = memberRepository.findByLoginId(request.getLoginId())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 로그인 아이디 나 패스워드 입니다"));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND));
 
         return passwordEncoder.matches(request.getPassword(), member.getPassword());
         //entity 객체인 member의 password와 요청dto로 들어온 request의 password를 비교해서

--- a/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
+++ b/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package discordstudy.calender.global.config;
 
+import discordstudy.calender.global.config.jwt.JwtTokenFilter;
+import discordstudy.calender.global.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,11 +11,15 @@ import org.springframework.security.config.annotation.web.configurers.LogoutConf
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 //Spring Security 에서 보안 설정을 활성화 하기 위해서 사용하는 애노테이션
 public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
     //시큐리티 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -22,7 +29,9 @@ public class SecurityConfig {
                         .requestMatchers("/", "/members/*").permitAll()//
                         .anyRequest().authenticated()//그외의 모든 요청은 인증요구
                 )
-                .logout(LogoutConfigurer::permitAll); // 로그아웃 접근도 모두 허용
+                .logout(LogoutConfigurer::permitAll) // 로그아웃 접근도 모두 허용
+                .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
+++ b/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
@@ -13,26 +13,24 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 //Spring Security 에서 보안 설정을 활성화 하기 위해서 사용하는 애노테이션
 public class SecurityConfig {
-//시큐리티 설정
+    //시큐리티 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf->csrf.disable())
-                .authorizeHttpRequests((requests)->requests
-                        .requestMatchers("/","/members/*").permitAll()//
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/", "/members/*").permitAll()//
                         .anyRequest().authenticated()//그외의 모든 요청은 인증요구
                 )
                 .logout(LogoutConfigurer::permitAll); // 로그아웃 접근도 모두 허용
 
-                return http.build();
+        return http.build();
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder()
-    {
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();//Bcrypt 패스워드 인코딩 방식 사용 !
     }
-
 
 
 }

--- a/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenFilter.java
@@ -1,0 +1,28 @@
+package discordstudy.calender.global.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = jwtTokenProvider.resolveToken(request);
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
@@ -1,11 +1,20 @@
 package discordstudy.calender.global.config.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -18,11 +27,20 @@ public class JwtTokenProvider {
     @Value("${jwt.ExpirationInMs}")//yaml 파일에 있는 expire length
     private long validityInMilliseconds;
 
-    //Secret Key를 Base64로 인코딩
-    protected void init()
-    {
-        secretKey= Base64.getEncoder().encodeToString(secretKey.getBytes());
+    private Key key;
+    private final UserDetailsService userDetailsService;
+
+    public JwtTokenProvider(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
     }
+
+
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
 
     public String createToken(String username, List<String> roles) {
         Claims claims = Jwts.claims().setSubject(username);
@@ -35,10 +53,35 @@ public class JwtTokenProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(validity)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
     }
 
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = this.userDetailsService.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
 
 
 }

--- a/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,44 @@
+package discordstudy.calender.global.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtTokenProvider {
+    @Value("${secret_key}")//yaml 파일에 있는 secret key
+    private String secretKey;
+
+    @Value("${ExpirationInMs")//yaml 파일에 있는 expire length
+    private long validityInMilliseconds;
+
+    //Secret Key를 Base64로 인코딩
+    protected void init()
+    {
+        secretKey= Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String createToken(String username, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("roles", roles);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+
+
+}

--- a/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/discordstudy/calender/global/config/jwt/JwtTokenProvider.java
@@ -12,10 +12,10 @@ import java.util.List;
 
 @Component
 public class JwtTokenProvider {
-    @Value("${secret_key}")//yaml 파일에 있는 secret key
+    @Value("${jwt.secret_key}")//yaml 파일에 있는 secret key
     private String secretKey;
 
-    @Value("${ExpirationInMs")//yaml 파일에 있는 expire length
+    @Value("${jwt.ExpirationInMs}")//yaml 파일에 있는 expire length
     private long validityInMilliseconds;
 
     //Secret Key를 Base64로 인코딩

--- a/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
+++ b/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 비밀번호가 일치하지 않습니다."),
+    DUPLICATED_LOGINID(HttpStatus.CONFLICT,"중복된 로그인 아이디 입니다"),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
+++ b/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 비밀번호가 일치하지 않습니다."),
     DUPLICATED_LOGINID(HttpStatus.CONFLICT,"중복된 로그인 아이디 입니다"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST,"유효하지 않은 로그인id와 비밀번호입니다"),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,5 @@ spring:
       ddl-auto: update
     open-in-view: false
 jwt:
-
   secret_key: ${JWT_SECRET}
   ExpirationInMs: 604800000 #7일

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,6 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+jwt:
+  issuer: cmwmss59@gmail.com
+  secret_key: ${JWT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,6 @@ spring:
       ddl-auto: update
     open-in-view: false
 jwt:
-  issuer: cmwmss59@gmail.com
+
   secret_key: ${JWT_SECRET}
   ExpirationInMs: 604800000 #7일

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,4 @@ spring:
 jwt:
   issuer: cmwmss59@gmail.com
   secret_key: ${JWT_SECRET}
+  ExpirationInMs: 604800000 #7일


### PR DESCRIPTION
# ⭐️ Pull Request 요약

- Jwt Token을 만드는 JwtTokenProvider 클래스를 만들고 이를 이용해서 Security Config 설정과 연동함


## 💡 관련 이슈

- #19 

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-04)
- 작업 종료일: (2024-09-04)

## 변경 사항
전통적인 로그인 방식으로 원래는 request의 loginid와 password만 받아서 로그인을 했는데

JWT 토큰 방식을 추가해서 로그인 / 회원가입이 성공한 회원을 찾아냄 

JWT  토큰을 추가한 방식 = > JwtTokenProvider 구성 !  


## 큰 흐름 정리

## 회원가입 : (/member/signup)

- 클라이언트가 login id , password , nickname 을 포함한 request를 보내면
- MemberController가 MemberService의 registermember 메서드를 호출하고
- MemberService에서 중복 loginid를 체크하고 회원가입을 성공함

## 로그인 (member/login)

- 클라이언트의 loginid password를 포함한 request 요청
- MemberController에서 MemberService의 authenticate 메서드 호출
- MemberService는 MemberRepository의 request의 loginid 확인
- 존재하면 비밀번호가 존재하는지 체크하고
- 마지막으로 Member의 loginid와 역할(user,admin)인지를 토큰에 정보를 담아 보내줌

## 인증 요청

- 클라이언트는 JWT를 받고  Authorization 헤더에 포함시켜 요청을 보냄
- JwtAuthenticationFilter가 요청을 가로채 토큰을 검증합니다.
- 토큰이 유효하면 SecurityContext에 인증 정보를 설정합니다.


##열거형 

@Enumerated(EnumType.STRING)//Role 문자열로 저장
@Column(name="role",nullable = false)
private Role role;

⇒ 역할을 MemberEntity에 구성 해주는 부분 ! 

EnumType.String 의 장점 

- ADMIN USER처럼 문자열로 하면 가독성 향상
- 문자열 방식은 대부분의 시스템에서 거의 동일한 로직으로 처리하므로 db간 이식성이 좋음
- `EnumType.STRING`을 사용하면 Enum의 순서를 변경해도 기존 데이터에는 영향을 미치지 않으므로 유지보수에 유리

##Repository

**`existByLoginId(String loginid)`**:

- `existBy`: JPA는 이 키워드를 보고 **"존재 여부를 확인하는 쿼리"**를 생성합니다. 이 메서드는 `boolean` 타입의 값을 반환합니다.
- `LoginId`: 이는 엔티티에 정의된 필드 이름을 가리킵니다. 예를 들어, 엔티티 클래스에서 `loginId`라는 필드를 사용하고 있다면, 해당 필드의 값을 기반으로 존재 여부를 체크하는 쿼리가 실행됩니다.

### 궁금했던점 ⇒ Entity 필드는 loginid 소문자인데 왜 여기는 LoginId 대문자임?

- 엔티티에 정의된 필드 이름이 소문자로 시작하는 `loginid`라면, `existByLoginId`에서 Camel Case 규칙을 적용해 **필드 이름의 첫 글자는 대문자로 변환**됩니다.
- 이때 `loginid`가 `existByLoginId`로 변환되는 것은 JPA가 필드 이름을 인식하고 처리하는 방식입니다. JPA는 메서드 이름을 분석하여 필드 이름과 매칭할 때, 대소문자를 구분하지 않고 매칭할 수 있습니다.

## Spring Security 에서 CustomUserDetails 이용하기

- 시큐리티 내부의 UserDetails를 이용하는것도 좋지만
- 조금더 커스터마이징 하고 싶다면 CustomUserDetails를 이용하는것도 좋다

### `addFilterBefore`의 역할:

`addFilterBefore` 메서드는 두 가지 주요 인자를 받습니다:

1. **추가할 필터**: 직접 정의하거나 Spring Security에서 제공하는 필터.
2. **기존 필터**: 새로 추가할 필터를 이 필터의 **앞에** 추가합니다.

### 요약:

- *`addFilterBefore`*는 Spring Security 필터 체인에서 **특정 필터 앞에** 새 필터를 추가하여, 요청이 해당 필터를 먼저 통과하게 만드는 메서드입니다.
- 이를 통해 커스텀 필터(예: JWT 필터)를 기존 필터보다 먼저 적용할 수 있으며, 보안 로직의 순서를 제어할 수 있습니다.

/## JwtTokenFilter

- **필터 체인 계속 진행**: 마지막으로 `filterChain.doFilter`를 호출하여, 다음 필터로 요청을 넘겨 계속 처리합니다.
filterChain.doFilter(request, response): 이 메서드는 다음 필터로 요청을 전달하는 역할을 합니다.

## 이내용을 코드 포함 정리한 링크 Notion ! 

https://www.notion.so/6-9-7-e1570947adba44239a342d37ff2b6870


## 이 PR을 하면서 느낀 총평

Jwt 토큰을 이용한 로그인 / 회원가입 구현은 Filter나 Security 설정 JwtToken을 생성하고 검증하고
Http 헤더에 Authorization이라는 초보에게 엄청나게 많은개념이 들어와서 한번씩 경험해보는데 많은 경험치를 얻은것 같음

물론 새롭게 알게된 사실에 있는 모든 내용을 바로 외우고 바로 적용할수 있는건 아니지만 이제 찾아보거나 대강의 순서도는 잡혀서 어떤식으로 구성해야지 ? 를 알 수 있는 좋은 경험이 된거 같음 

Service 와 Repo Controller의 연결과 토큰 발급을 위한 JwtTokenFilter, JwtTokenProvider ,SecurityConfig ,CustomUserDetailsService , UserDetail 등 많은 걸 해볼 수 있는 구성이었다 

