### PR TITLE
[Feat] 게시판 기능의 CUD를 추가한다

### DIFF
--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -1,0 +1,33 @@
+package discordstudy.calender.domain.post.controller;
+
+import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.service.PostService;
+import discordstudy.calender.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> postPost(
+            @RequestBody PostRequest request,
+            Authentication authentication
+    ) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        postService.postPost(request, userDetails.getUsername());
+
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -28,6 +28,19 @@ public class PostController {
         return ApiResponse.ok();
     }
 
+    @PutMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> postUpdate(
+            @RequestBody PostRequest request,
+            @PathVariable Long postId,
+            Authentication authentication
+    ) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        postService.postUpdate(request, postId, userDetails.getUsername());
+
+        return ApiResponse.ok();
+    }
+
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postDelete(
             @PathVariable Long postId,
@@ -35,7 +48,7 @@ public class PostController {
     ) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
-        postService.postDelete(userDetails.getUsername(), postId);
+        postService.postDelete(postId, userDetails.getUsername());
 
         return ApiResponse.ok();
     }

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package discordstudy.calender.domain.post.controller;
 
 import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.dto.PostResponse;
 import discordstudy.calender.domain.post.service.PostService;
 import discordstudy.calender.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +18,17 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Void>> postPost(
+    public ResponseEntity<ApiResponse<PostResponse>> postPost(
             @RequestBody PostRequest request,
             Authentication authentication
     ) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
-        postService.postPost(request, userDetails.getUsername());
-
-        return ApiResponse.ok();
+        return ApiResponse.ok(
+                new PostResponse(
+                        postService.postPost(request, userDetails.getUsername())
+                )
+        );
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +24,18 @@ public class PostController {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
         postService.postPost(request, userDetails.getUsername());
+
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> postDelete(
+            @PathVariable Long postId,
+            Authentication authentication
+    ) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        postService.postDelete(userDetails.getUsername(), postId);
 
         return ApiResponse.ok();
     }

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostRequest.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostRequest.java
@@ -1,0 +1,11 @@
+package discordstudy.calender.domain.post.dto;
+
+import java.util.Set;
+
+public record PostRequest(
+        String title,
+        String content,
+//        Category category,
+        Set<String> hashtag
+) {
+}

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostResponse.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostResponse.java
@@ -1,0 +1,6 @@
+package discordstudy.calender.domain.post.dto;
+
+public record PostResponse(
+        Long postId
+) {
+}

--- a/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
@@ -1,0 +1,22 @@
+package discordstudy.calender.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", length = 20)
+    private String tag;
+
+    @OneToMany(mappedBy = "hashtag", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HashtagMap> hashtagMaps = new HashSet<>();
+}

--- a/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
@@ -2,12 +2,14 @@ package discordstudy.calender.domain.post.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
 
 @Getter
 @Entity
+@NoArgsConstructor
 public class Hashtag {
 
     @Id
@@ -17,6 +19,15 @@ public class Hashtag {
     @Column(name = "content", length = 20)
     private String tag;
 
-    @OneToMany(mappedBy = "hashtag", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(
+            mappedBy = "post",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
     private Set<HashtagMap> hashtagMaps = new HashSet<>();
+
+    public Hashtag(String tag) {
+        this.tag = tag;
+    }
 }

--- a/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Hashtag.java
@@ -16,11 +16,11 @@ public class Hashtag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "content", length = 20)
+    @Column(name = "content", length = 20, unique = true)
     private String tag;
 
     @OneToMany(
-            mappedBy = "post",
+            mappedBy = "hashtag",
             cascade = CascadeType.ALL,
             orphanRemoval = true,
             fetch = FetchType.LAZY

--- a/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
@@ -1,0 +1,21 @@
+package discordstudy.calender.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class HashtagMap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "postId")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "hashtagId")
+    private Hashtag hashtag;
+}

--- a/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
@@ -2,9 +2,11 @@ package discordstudy.calender.domain.post.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor
 public class HashtagMap {
 
     @Id
@@ -18,4 +20,8 @@ public class HashtagMap {
     @ManyToOne
     @JoinColumn(name = "hashtagId")
     private Hashtag hashtag;
+
+    public HashtagMap(Hashtag hashtag) {
+        this.hashtag = hashtag;
+    }
 }

--- a/src/main/java/discordstudy/calender/domain/post/entity/Post.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Post.java
@@ -35,6 +35,7 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
+    @Setter
     @OneToMany(
             mappedBy = "post",
             cascade = CascadeType.ALL,

--- a/src/main/java/discordstudy/calender/domain/post/entity/Post.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Post.java
@@ -1,0 +1,38 @@
+package discordstudy.calender.domain.post.entity;
+
+import discordstudy.calender.domain.member.entity.Member;
+import discordstudy.calender.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @Column //카테고리 분류를 먼저 정해야 하므로 일단 보류
+//    @Enumerated(EnumType.STRING)
+//    private Category category;
+
+    @Setter
+    @Column(name = "title", length = 20)
+    private String title;
+
+    @Setter
+    @Column(name = "content")
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HashtagMap> hashtagMaps = new HashSet<>();
+}

--- a/src/main/java/discordstudy/calender/domain/post/entity/Post.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/Post.java
@@ -3,14 +3,16 @@ package discordstudy.calender.domain.post.entity;
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.HashSet;
 import java.util.Set;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Post extends BaseTimeEntity {
 
     @Id
@@ -33,6 +35,11 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(
+            mappedBy = "post",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
     private Set<HashtagMap> hashtagMaps = new HashSet<>();
 }

--- a/src/main/java/discordstudy/calender/domain/post/repository/HashtagRepository.java
+++ b/src/main/java/discordstudy/calender/domain/post/repository/HashtagRepository.java
@@ -1,0 +1,12 @@
+package discordstudy.calender.domain.post.repository;
+
+import discordstudy.calender.domain.post.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Set;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    List<Hashtag> findByTagIn(Set<String> tags);
+}

--- a/src/main/java/discordstudy/calender/domain/post/repository/PostRepository.java
+++ b/src/main/java/discordstudy/calender/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package discordstudy.calender.domain.post.repository;
+
+import discordstudy.calender.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -5,9 +5,11 @@ import discordstudy.calender.domain.member.repository.MemberRepository;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.entity.Hashtag;
 import discordstudy.calender.domain.post.entity.HashtagMap;
+import discordstudy.calender.domain.post.entity.Post;
 import discordstudy.calender.domain.post.repository.HashtagRepository;
 import discordstudy.calender.domain.post.repository.PostRepository;
 import discordstudy.calender.domain.post.util.PostConverter;
+import discordstudy.calender.domain.team.enums.Role;
 import discordstudy.calender.global.exception.ApplicationException;
 import discordstudy.calender.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +50,20 @@ public class PostService {
                 .forEach(existTags::add);
 
         return existTags;
+    }
+
+    @Transactional
+    public void postDelete(String loginId, Long postId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_EXIST));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.POST_NOT_EXIST));
+
+        if (!member.getId().equals(post.getMember().getId()) || !(member.getRole() == Role.ADMIN)) {
+            throw new ApplicationException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        postRepository.delete(post);
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -1,0 +1,52 @@
+package discordstudy.calender.domain.post.service;
+
+import discordstudy.calender.domain.member.entity.Member;
+import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.entity.Hashtag;
+import discordstudy.calender.domain.post.entity.HashtagMap;
+import discordstudy.calender.domain.post.repository.HashtagRepository;
+import discordstudy.calender.domain.post.repository.PostRepository;
+import discordstudy.calender.domain.post.util.PostConverter;
+import discordstudy.calender.global.exception.ApplicationException;
+import discordstudy.calender.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final HashtagRepository hashtagRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void postPost(PostRequest request, String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_EXIST));
+
+        List<Hashtag> hashtags = handlingHashtag(request.hashtag());
+
+        Set<HashtagMap> hashtagMaps = hashtags.stream().map(HashtagMap::new).collect(Collectors.toSet());
+
+        postRepository.save(PostConverter.createPost(request, member, hashtagMaps));
+    }
+
+    private List<Hashtag> handlingHashtag(Set<String> hashtag) {
+        List<Hashtag> existTags = hashtagRepository.findByTagIn(hashtag);
+
+        hashtagRepository.saveAll(
+                        hashtag.stream().filter(tag -> !existTags.contains(tag))
+                                .map(Hashtag::new).toList()
+                )
+                .forEach(existTags::add);
+
+        return existTags;
+    }
+}

--- a/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
+++ b/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
@@ -1,0 +1,20 @@
+package discordstudy.calender.domain.post.util;
+
+import discordstudy.calender.domain.member.entity.Member;
+import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.entity.HashtagMap;
+import discordstudy.calender.domain.post.entity.Post;
+
+import java.util.Set;
+
+public class PostConverter {
+
+    public static Post createPost(PostRequest request, Member member, Set<HashtagMap> hashtagMaps) {
+        return Post.builder()
+                .title(request.title())
+                .content(request.content())
+                .hashtagMaps(hashtagMaps)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/discordstudy/calender/global/entity/BaseTimeEntity.java
+++ b/src/main/java/discordstudy/calender/global/entity/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package discordstudy.calender.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 생성, 수정 시간 관리를 위한 Entity
+ * 해당 필드 관리가 필요한 엔티티에 상속하여 사용
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreationTimestamp
+    protected LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
+++ b/src/main/java/discordstudy/calender/global/exception/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode {
     DUPLICATED_LOGINID(HttpStatus.CONFLICT,"중복된 로그인 아이디 입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST,"유효하지 않은 로그인id와 비밀번호입니다"),
 
+    // POST
+    POST_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 게시글입니다."),
+
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 


### PR DESCRIPTION
# ⭐️ Pull Request 요약

- 게시판 기능의 CUD 에 대한 코드입니다.
- Post 관련 API가 추가됩니다

## 🛠️ 변경 사항
- PostController :
  - Post 생성, 수정, 삭제 API 추가
- PostService :
  - Post 생성, 수정, 삭제 용도의 메소드 추가
  - hashtag 변경에 대한 관리를 위해 handlingHashtag 메소드 추가
  - 
- Entity :
  - Hashtag, HashtagMap, Post 엔티티 추가
  - 엔티티 생성 관리 및 디버깅에 용이하도록 BaseTimeEntity 추가
- DTO :
  - PostRequest, PostResponse Record 클래스 추가
- Repository :
  - Post, Hashtag 레포지토리 추가
- PostConverter : Post 객체를 생성하기 위한 정적 메소드 추가
## 💡 관련 이슈

- #23

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-09)
- 작업 종료일: (2024-09-12)

## 📌 제안사항
- 현재 프로젝트에서 응답에 1가지 값만 존재하는 경우에도 억지로 값을 래핑하고 있음 -> 과한 래핑은 사용이 힘들어 질 수 있겠다고 생각함

## 🔗 참고문헌

- [매핑된 객체를 대체할 때 부작용](https://velog.io/@gnoesnooj/ERROR-A-collection-with-cascadeall-delete-orphan-was-no-longer-referenced-by-the-owning-entity-instance)
