### PR TITLE
[Test] Post CUD 에 대한 테스트 코드 추가

### DIFF
--- a/src/test/java/discordstudy/calender/domain/post/service/PostServiceTest.java
+++ b/src/test/java/discordstudy/calender/domain/post/service/PostServiceTest.java
@@ -8,11 +8,24 @@ import discordstudy.calender.domain.post.repository.HashtagRepository;
 import discordstudy.calender.domain.post.repository.PostRepository;
 import discordstudy.calender.domain.team.enums.Role;
 import discordstudy.calender.global.exception.ApplicationException;
-import org.junit.jupiter.api.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.util.Optional;
 import java.util.Set;
+
+import static discordstudy.calender.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("PostService 클래스의 ")
 class PostServiceTest {
@@ -27,11 +40,27 @@ class PostServiceTest {
     @InjectMocks
     private PostService postService;
 
-    private Member member = new Member(
+    private Member authorMember = new Member(
             1L,
             "loginId",
             "홍길동",
             "길동",
+            Role.MEMBER
+    );
+
+    private Member admin = new Member(
+            2L,
+            "adminId",
+            "어드민",
+            "password",
+            Role.ADMIN
+    );
+
+    private Member otherMember = new Member(
+            2L,
+            "loginIds",
+            "고길동",
+            "password",
             Role.MEMBER
     );
 
@@ -45,7 +74,7 @@ class PostServiceTest {
             1L,
             "게시글",
             "내용",
-            member,
+            authorMember,
             null
     );
 
@@ -63,19 +92,17 @@ class PostServiceTest {
         void successTest() {
             //Given
             //BDD Mockito 라이브러리 채용
-            BDDMockito.
-                    given(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
-                    .willReturn(Optional.of(member));
+            BDDMockito.given(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
+                    .willReturn(Optional.of(authorMember));
 
-            BDDMockito.
-                    given(postRepository.save(ArgumentMatchers.any(Post.class)))
+            given(postRepository.save(ArgumentMatchers.any(Post.class)))
                     .willReturn(post);
 
             //When
-            Long result = postService.postPost(successRequest, "loginId");
+            Long result = postService.postPost(successRequest, authorMember.getLoginId());
 
             //Then
-            org.assertj.core.api.Assertions.assertThat(result).isEqualTo(post.getId());
+            Assertions.assertThat(result).isEqualTo(post.getId());
         }
 
         @DisplayName("유저가 존재하지 않아 실패한다")
@@ -86,8 +113,13 @@ class PostServiceTest {
             Mockito.when(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
                     .thenReturn(Optional.empty());
 
-            Assertions.assertThrows(ApplicationException.class,
-                    () -> postService.postPost(successRequest, "loginId"));
+            //When
+            //원하는 Exception 이 발생했는지 확인하는 코드
+            ApplicationException result = assertThrows(ApplicationException.class,
+                    () -> postService.postPost(successRequest, authorMember.getLoginId()));
+
+            //Then
+            assertThat(result.getErrorCode()).isEqualTo(USER_NOT_EXIST);
         }
     }
 
@@ -95,6 +127,87 @@ class PostServiceTest {
     @DisplayName("postDelete() 메소드는")
     class PostDeleteTest {
 
+        @DisplayName("본인이 삭제에 성공한다")
+        @Test
+        void successByAuthorTest() {
+            //Given
+            given(memberRepository.findByLoginId(anyString()))
+                    .willReturn(Optional.of(authorMember));
+
+            given(postRepository.findById(anyLong()))
+                    .willReturn(Optional.of(post));
+            //When
+            postService.postDelete(post.getId(), authorMember.getLoginId());
+
+            //Then
+            //기대하는 메소드가 times 만큼 실행되었는지 확인하는 코드
+            verify(postRepository, times(1)).delete(post);
+        }
+
+        @DisplayName("관리자가 삭제에 성공한다")
+        @Test
+        void successByAdminTest() {
+            //Given
+            given(memberRepository.findByLoginId(anyString()))
+                    .willReturn(Optional.of(admin));
+
+            given(postRepository.findById(anyLong()))
+                    .willReturn(Optional.of(post));
+            //When
+            postService.postDelete(post.getId(), "admin");
+
+            //Then
+            verify(postRepository, times(1)).delete(post);
+        }
+
+        @DisplayName("유저가 존재하지 않아 실패한다")
+        @Test
+        void failAboutNotExistMember() {
+            //Given
+            given(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
+                    .willReturn(Optional.empty());
+
+            //When
+            ApplicationException result = assertThrows(ApplicationException.class,
+                    () -> postService.postDelete(post.getId(), "notExistId"));
+
+            //Then
+            assertThat(result.getErrorCode()).isEqualTo(USER_NOT_EXIST);
+        }
+
+        @DisplayName("게시글이 존재하지 않아 실패한다")
+        @Test
+        void failAboutNotExistPost() {
+            //Given
+            given(memberRepository.findByLoginId(anyString()))
+                    .willReturn(Optional.of(authorMember));
+
+            given(postRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            //When
+            ApplicationException result = assertThrows(ApplicationException.class,
+                    () -> postService.postDelete(post.getId(), authorMember.getLoginId()));
+
+            //Then
+            assertThat(result.getErrorCode()).isEqualTo(POST_NOT_EXIST);
+        }
+
+        @DisplayName("작성자가 달라 삭제에 실패한다")
+        @Test
+        void failByDifferentAuthor() {
+            //Given
+            given(memberRepository.findByLoginId(anyString()))
+                    .willReturn(Optional.of(otherMember));
+
+            given(postRepository.findById(anyLong()))
+                    .willReturn(Optional.of(post));
+            //Then & When
+            ApplicationException result = assertThrows(ApplicationException.class,
+                    () -> postService.postDelete(post.getId(), otherMember.getLoginId()));
+
+            assertThat(result.getErrorCode()).isEqualTo(UNAUTHORIZED_ACCESS);
+        }
     }
 
     @Nested
@@ -103,3 +216,5 @@ class PostServiceTest {
 
     }
 }
+
+

--- a/src/test/java/discordstudy/calender/domain/post/service/PostServiceTest.java
+++ b/src/test/java/discordstudy/calender/domain/post/service/PostServiceTest.java
@@ -1,0 +1,105 @@
+package discordstudy.calender.domain.post.service;
+
+import discordstudy.calender.domain.member.entity.Member;
+import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.entity.Post;
+import discordstudy.calender.domain.post.repository.HashtagRepository;
+import discordstudy.calender.domain.post.repository.PostRepository;
+import discordstudy.calender.domain.team.enums.Role;
+import discordstudy.calender.global.exception.ApplicationException;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.util.Optional;
+import java.util.Set;
+
+@DisplayName("PostService 클래스의 ")
+class PostServiceTest {
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Member member = new Member(
+            1L,
+            "loginId",
+            "홍길동",
+            "길동",
+            Role.MEMBER
+    );
+
+    private PostRequest successRequest = new PostRequest(
+            "게시글",
+            "내용",
+            Set.of("해시택")
+    );
+
+    private Post post = new Post(
+            1L,
+            "게시글",
+            "내용",
+            member,
+            null
+    );
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("postPost() 메소드는")
+    class PostPostTest {
+
+        @DisplayName("성공한다")
+        @Test
+        void successTest() {
+            //Given
+            //BDD Mockito 라이브러리 채용
+            BDDMockito.
+                    given(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
+                    .willReturn(Optional.of(member));
+
+            BDDMockito.
+                    given(postRepository.save(ArgumentMatchers.any(Post.class)))
+                    .willReturn(post);
+
+            //When
+            Long result = postService.postPost(successRequest, "loginId");
+
+            //Then
+            org.assertj.core.api.Assertions.assertThat(result).isEqualTo(post.getId());
+        }
+
+        @DisplayName("유저가 존재하지 않아 실패한다")
+        @Test
+        void failAboutNotExistMember() {
+            //Given
+            //Mockito 라이브러리 채용
+            Mockito.when(memberRepository.findByLoginId(ArgumentMatchers.anyString()))
+                    .thenReturn(Optional.empty());
+
+            Assertions.assertThrows(ApplicationException.class,
+                    () -> postService.postPost(successRequest, "loginId"));
+        }
+    }
+
+    @Nested
+    @DisplayName("postDelete() 메소드는")
+    class PostDeleteTest {
+
+    }
+
+    @Nested
+    @DisplayName("postUpdate() 메소드는")
+    class PostUpdateTest {
+
+    }
+}


### PR DESCRIPTION
# ⭐️ Pull Request 요약
- 게시판의 CUD 기능에 테스트 코드를 추가한다
- post : 성공 케이스 1, 실패 케이스  1
- update : 성공 케이스  1, 실패 케이스  3
- delete : 성공케이스 2, 실패케이스 3

## 🛠️ 변경 사항

- Post의 CUD에 테스트 케이스를 추가합니다.

## 💡 관련 이슈

- #23 

## ⏱️ 작업 기간

- 작업 시작일: (2024-09-25)
- 작업 종료일:(2024-09-26)

## 📌 유의사항

- 코드에서 어떤 클래스를 사용하는지 보여주기 위해 의도적으로 정적 임포트를 사용하지 않은 구문이 존재합니다

## 🔗 참고문헌

- 참조한 레퍼런스 링크
- [테스트코드를 왜 작성할까?](https://tech.inflab.com/20230404-test-code/)
- [@Nested 어노테이션](https://johngrib.github.io/wiki/junit5-nested/)
- [Mock 객체란?](https://happy-coding-day.tistory.com/163)
  - [Mock vs Stub](https://ssyoni.tistory.com/31)
- [BDD](https://www.devkuma.com/docs/testing/bdd/)
  - BDD 의 Given - When - Then 패턴을 차용함
- [ArgumentCaptor](https://recordsoflife.tistory.com/738)
- 어려운 내용이 많음....한 번에 다 공부할 생각은 하지 말고 천천히 해야 함