### PR TITLE
[Feat] 게시판 조회 기능 추가

### DIFF
--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package discordstudy.calender.domain.post.controller;
 
 import discordstudy.calender.domain.post.dto.PostAllResponse;
 import discordstudy.calender.domain.post.dto.PostCreateResponse;
+import discordstudy.calender.domain.post.dto.PostDetailResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.service.PostService;
 import discordstudy.calender.global.dto.ApiResponse;
@@ -62,11 +63,11 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<PostAllResponse>>> postFindAll(
+    public ResponseEntity<ApiResponse<PageResponse<PostAllResponse>>> postAll(
             @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageRequest
     ) {
         return ApiResponse.ok(
-                postService.postFindAll(pageRequest)
+                postService.postAll(pageRequest)
         );
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -1,10 +1,15 @@
 package discordstudy.calender.domain.post.controller;
 
+import discordstudy.calender.domain.post.dto.PostAllResponse;
 import discordstudy.calender.domain.post.dto.PostCreateResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.service.PostService;
 import discordstudy.calender.global.dto.ApiResponse;
+import discordstudy.calender.global.dto.PageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -54,5 +59,14 @@ public class PostController {
         postService.postDelete(postId, userDetails.getUsername());
 
         return ApiResponse.ok();
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<PostAllResponse>>> postFindAll(
+            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageRequest
+    ) {
+        return ApiResponse.ok(
+                postService.postFindAll(pageRequest)
+        );
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -1,7 +1,7 @@
 package discordstudy.calender.domain.post.controller;
 
+import discordstudy.calender.domain.post.dto.PostCreateResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
-import discordstudy.calender.domain.post.dto.PostResponse;
 import discordstudy.calender.domain.post.service.PostService;
 import discordstudy.calender.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +18,14 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PostResponse>> postPost(
+    public ResponseEntity<ApiResponse<PostCreateResponse>> postPost(
             @RequestBody PostRequest request,
             Authentication authentication
     ) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
         return ApiResponse.ok(
-                new PostResponse(
+                new PostCreateResponse(
                         postService.postPost(request, userDetails.getUsername())
                 )
         );

--- a/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
+++ b/src/main/java/discordstudy/calender/domain/post/controller/PostController.java
@@ -70,4 +70,11 @@ public class PostController {
                 postService.postAll(pageRequest)
         );
     }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostDetailResponse>> postDetail(@PathVariable Long postId){
+        return ApiResponse.ok(
+                postService.postDetail(postId)
+        );
+    }
 }

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostAllResponse.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostAllResponse.java
@@ -1,0 +1,12 @@
+package discordstudy.calender.domain.post.dto;
+
+import java.util.Set;
+
+public record PostAllResponse(
+        Long postId,
+        String title,
+        String content,
+//        Category category,
+        Set<String> hashtag
+) {
+}

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostAllResponse.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostAllResponse.java
@@ -5,7 +5,6 @@ import java.util.Set;
 public record PostAllResponse(
         Long postId,
         String title,
-        String content,
 //        Category category,
         Set<String> hashtag
 ) {

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostCreateResponse.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostCreateResponse.java
@@ -1,6 +1,6 @@
 package discordstudy.calender.domain.post.dto;
 
-public record PostResponse(
+public record PostCreateResponse(
         Long postId
 ) {
 }

--- a/src/main/java/discordstudy/calender/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/discordstudy/calender/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,11 @@
+package discordstudy.calender.domain.post.dto;
+
+import java.util.Set;
+
+public record PostDetailResponse(
+        String title,
+        String content,
+//        Category category,
+        Set<String> hashtag
+) {
+}

--- a/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
+++ b/src/main/java/discordstudy/calender/domain/post/entity/HashtagMap.java
@@ -3,6 +3,7 @@ package discordstudy.calender.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -13,6 +14,7 @@ public class HashtagMap {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "postId")
     private Post post;

--- a/src/main/java/discordstudy/calender/domain/post/repository/PostRepository.java
+++ b/src/main/java/discordstudy/calender/domain/post/repository/PostRepository.java
@@ -1,7 +1,13 @@
 package discordstudy.calender.domain.post.repository;
 
 import discordstudy.calender.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @EntityGraph(attributePaths = {"hashtagMaps", "hashtagMaps.hashtag"})
+    Page<Post> findAll(Pageable pageable);
 }

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package discordstudy.calender.domain.post.service;
 
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.domain.post.dto.PostAllResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.entity.Hashtag;
 import discordstudy.calender.domain.post.entity.HashtagMap;
@@ -10,9 +11,13 @@ import discordstudy.calender.domain.post.repository.HashtagRepository;
 import discordstudy.calender.domain.post.repository.PostRepository;
 import discordstudy.calender.domain.post.util.PostConverter;
 import discordstudy.calender.domain.team.enums.Role;
+import discordstudy.calender.global.dto.PageResponse;
+import discordstudy.calender.global.dto.util.PageConverter;
 import discordstudy.calender.global.exception.ApplicationException;
 import discordstudy.calender.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +40,11 @@ public class PostService {
 
         Set<HashtagMap> hashtagMaps = handlingHashtag(request.hashtag());
 
-        return postRepository.save(PostConverter.createPost(request, member, hashtagMaps)).getId();
+        Post post = postRepository.save(PostConverter.createPost(request, member, hashtagMaps));
+
+        hashtagMaps.forEach(hashtagMap -> hashtagMap.setPost(post));
+
+        return post.getId();
     }
 
     private Set<HashtagMap> handlingHashtag(Set<String> hashtags) {
@@ -95,6 +104,8 @@ public class PostService {
         Set<HashtagMap> hashtagMaps = handlingHashtag(request.hashtag());
         post.getHashtagMaps().clear();
         post.getHashtagMaps().addAll(hashtagMaps);
+
+        hashtagMaps.forEach(hm->hm.setPost(post));
 
         return post;
     }

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package discordstudy.calender.domain.post.service;
 
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
+import discordstudy.calender.domain.post.dto.PostDetailResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.entity.Hashtag;
 import discordstudy.calender.domain.post.entity.HashtagMap;
@@ -111,7 +112,15 @@ public class PostService {
     @Transactional(readOnly = true)
     public PageResponse postAll(Pageable pageRequest) {
         return PageConverter.toDto(
-                postRepository.findAll(pageRequest).map(PostConverter::toDto)
+                postRepository.findAll(pageRequest).map(PostConverter::toAllDto)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public PostDetailResponse postDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND));
+
+        return PostConverter.toDetailDto(post);
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -2,7 +2,6 @@ package discordstudy.calender.domain.post.service;
 
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.member.repository.MemberRepository;
-import discordstudy.calender.domain.post.dto.PostAllResponse;
 import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.entity.Hashtag;
 import discordstudy.calender.domain.post.entity.HashtagMap;
@@ -16,7 +15,6 @@ import discordstudy.calender.global.dto.util.PageConverter;
 import discordstudy.calender.global.exception.ApplicationException;
 import discordstudy.calender.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -105,8 +103,15 @@ public class PostService {
         post.getHashtagMaps().clear();
         post.getHashtagMaps().addAll(hashtagMaps);
 
-        hashtagMaps.forEach(hm->hm.setPost(post));
+        hashtagMaps.forEach(hm -> hm.setPost(post));
 
         return post;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse postFindAll(Pageable pageRequest) {
+        return PageConverter.toDto(
+                postRepository.findAll(pageRequest).map(PostConverter::toDto)
+        );
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/service/PostService.java
+++ b/src/main/java/discordstudy/calender/domain/post/service/PostService.java
@@ -109,7 +109,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse postFindAll(Pageable pageRequest) {
+    public PageResponse postAll(Pageable pageRequest) {
         return PageConverter.toDto(
                 postRepository.findAll(pageRequest).map(PostConverter::toDto)
         );

--- a/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
+++ b/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
@@ -21,7 +21,7 @@ public class PostConverter {
     }
 
     public static PostAllResponse toDto(Post post) {
-        return new PostAllResponse(post.getId(), post.getTitle(), post.getTitle(),
+        return new PostAllResponse(post.getId(), post.getTitle(),
                 post.getHashtagMaps().stream()
                 .map(v -> v.getHashtag().getTag())
                         .collect(Collectors.toSet())

--- a/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
+++ b/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
@@ -2,10 +2,12 @@ package discordstudy.calender.domain.post.util;
 
 import discordstudy.calender.domain.member.entity.Member;
 import discordstudy.calender.domain.post.dto.PostRequest;
+import discordstudy.calender.domain.post.dto.PostAllResponse;
 import discordstudy.calender.domain.post.entity.HashtagMap;
 import discordstudy.calender.domain.post.entity.Post;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PostConverter {
 
@@ -16,5 +18,13 @@ public class PostConverter {
                 .hashtagMaps(hashtagMaps)
                 .member(member)
                 .build();
+    }
+
+    public static PostAllResponse toDto(Post post) {
+        return new PostAllResponse(post.getId(), post.getTitle(), post.getTitle(),
+                post.getHashtagMaps().stream()
+                .map(v -> v.getHashtag().getTag())
+                        .collect(Collectors.toSet())
+        );
     }
 }

--- a/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
+++ b/src/main/java/discordstudy/calender/domain/post/util/PostConverter.java
@@ -1,8 +1,9 @@
 package discordstudy.calender.domain.post.util;
 
 import discordstudy.calender.domain.member.entity.Member;
-import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.dto.PostAllResponse;
+import discordstudy.calender.domain.post.dto.PostDetailResponse;
+import discordstudy.calender.domain.post.dto.PostRequest;
 import discordstudy.calender.domain.post.entity.HashtagMap;
 import discordstudy.calender.domain.post.entity.Post;
 
@@ -20,10 +21,18 @@ public class PostConverter {
                 .build();
     }
 
-    public static PostAllResponse toDto(Post post) {
+    public static PostAllResponse toAllDto(Post post) {
         return new PostAllResponse(post.getId(), post.getTitle(),
                 post.getHashtagMaps().stream()
-                .map(v -> v.getHashtag().getTag())
+                        .map(v -> v.getHashtag().getTag())
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    public static PostDetailResponse toDetailDto(Post post) {
+        return new PostDetailResponse(post.getTitle(), post.getContent(),
+                post.getHashtagMaps().stream()
+                        .map(v -> v.getHashtag().getTag())
                         .collect(Collectors.toSet())
         );
     }

--- a/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
+++ b/src/main/java/discordstudy/calender/global/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/", "/members/*").permitAll()//
+                        .requestMatchers("/", "/members/*").permitAll()
+                        .requestMatchers("/posts","/posts/*").permitAll()
                         .anyRequest().authenticated()//그외의 모든 요청은 인증요구
                 )
                 .logout(LogoutConfigurer::permitAll) // 로그아웃 접근도 모두 허용

--- a/src/main/java/discordstudy/calender/global/dto/PageResponse.java
+++ b/src/main/java/discordstudy/calender/global/dto/PageResponse.java
@@ -1,0 +1,12 @@
+package discordstudy.calender.global.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        Integer pageSize,
+        Integer currentPage,
+        Long totalElements,
+        Integer totalPages,
+        List<T> articles
+) {
+}

--- a/src/main/java/discordstudy/calender/global/dto/util/PageConverter.java
+++ b/src/main/java/discordstudy/calender/global/dto/util/PageConverter.java
@@ -1,0 +1,17 @@
+package discordstudy.calender.global.dto.util;
+
+import discordstudy.calender.global.dto.PageResponse;
+import org.springframework.data.domain.Page;
+
+public class PageConverter {
+
+    public static PageResponse toDto(Page page) {
+        return new PageResponse<>(
+                page.getSize(),
+                page.getPageable().getPageNumber(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getContent()
+        );
+    }
+}


### PR DESCRIPTION
# ⭐️ Pull Request 요약

- 게시글 전체 조회 & 상세 조회 기능 구현

## 🛠️ 변경 사항

- PostController : 전체 조회 & 상세 조회 API 추가
- DTO :
  - PostResponse -> PostCreateResponse : 더 직관적인 이름으로 변경
  - 새 DTO 추가 : PostDetailResponse & PostAllResponse & PageResponse
- HashtagMap : 연관관계 설정하는 부분 추가
- PostRepository : findAll 메소드에 EntityGraph 사용하여 N+1 문제 방지
- PostService : 
  - 연관관계 설정하는 부분 추가
  - 조회용 메소드 추가
- PostConverter : 조회 DTO 변환 메소드 추가
- PageConverter : DTO 변환용 클래스 추가
- SecurityConfig : 게시글 경로 추가

## 💡 관련 이슈

- #23

## ⏱️ 작업 기간

- 작업 시작일: (2024-10-08)
- 작업 종료일: (2024-10-09)

## 🔗 참고문헌

- 조회 기능 작성중 N+1 문제 발생
  - [N+1 이란?](https://incheol-jung.gitbook.io/docs/q-and-a/spring/n+1)
  - #30 
